### PR TITLE
bump/github-actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         run: bash -x .test/test.sh "${{ matrix.chr }}"
 
       - name: artifacts | save
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@master
         with:
           name: backups-${{ matrix.chr }}
           path: 29e7738e-6f65-4991-998c-be1cc916803f/


### PR DESCRIPTION
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/upload-artifact@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/